### PR TITLE
Fix persistent cache visit count check

### DIFF
--- a/interactive_game.py
+++ b/interactive_game.py
@@ -4,6 +4,7 @@ import math
 import random
 from HivePocket.HivePocket import HiveGame  # Your Hive game implementation.
 from mcts.Mcts import MCTS                # Your MCTS class.
+from mcts.eval_cache import EvalCache
 
 # ---------------------- Hex Grid Helpers -------------------------
 HEX_SIZE = 40      # Radius of each hexagon.
@@ -298,6 +299,7 @@ def play_with_mcts():
     heatmap_colors = {}
 
     game = HiveGame()
+    cache = EvalCache()
 
     weights = {
         "winning_score": 10000,
@@ -313,7 +315,8 @@ def play_with_mcts():
                 c_param=1.4,
                 forced_check_depth=0,
                 weights=weights,
-                perspective_player="Player2")
+                perspective_player="Player2",
+                cache=cache)
     state = game.getInitialState()
     print("Initial board:")
     game.printState(state)

--- a/mcts/eval_cache.py
+++ b/mcts/eval_cache.py
@@ -1,0 +1,26 @@
+import os
+import pickle
+from typing import Dict, Tuple
+
+
+class EvalCache:
+    """Simple persistent cache for MCTS evaluations."""
+
+    def __init__(self, path: str = "mcts_eval_cache.pkl"):
+        self.path = path
+        if os.path.exists(self.path):
+            with open(self.path, "rb") as f:
+                self.data: Dict[str, Tuple[int, float]] = pickle.load(f)
+        else:
+            self.data: Dict[str, Tuple[int, float]] = {}
+
+    def get(self, key: str):
+        return self.data.get(key)
+
+    def increment(self, key: str, value: float):
+        visits, total = self.data.get(key, (0, 0.0))
+        self.data[key] = (visits + 1, total + value)
+
+    def save(self):
+        with open(self.path, "wb") as f:
+            pickle.dump(self.data, f)

--- a/mcts_game.py
+++ b/mcts_game.py
@@ -5,6 +5,7 @@ import json
 import datetime
 from HivePocket.HivePocket import HiveGame  # Your Hive game implementation.
 from mcts.Mcts import MCTS                # Your MCTS class.
+from mcts.eval_cache import EvalCache
 
 # ---------------------- Hex Grid Helpers -------------------------
 HEX_SIZE = 40      # Radius of each hexagon.
@@ -159,6 +160,7 @@ def play_mcts_vs_mcts():
     heatmap_colors = {}
 
     game = HiveGame()
+    cache = EvalCache()
 
     # ----------------- Define Agent Parameters Once -----------------
     params1 = {
@@ -190,8 +192,8 @@ def play_mcts_vs_mcts():
         "perspective_player": "Player2"
     }
 
-    mcts_player1 = MCTS(game, **params1)
-    mcts_player2 = MCTS(game, **params2)
+    mcts_player1 = MCTS(game, cache=cache, **params1)
+    mcts_player2 = MCTS(game, cache=cache, **params2)
 
     state = game.getInitialState()
     print("Initial board:")

--- a/tournament.py
+++ b/tournament.py
@@ -38,6 +38,7 @@ import pygame  # noqa: E402
 
 from HivePocket.HivePocket import HiveGame  # noqa: E402
 from mcts.Mcts import MCTS                 # noqa: E402
+from mcts.eval_cache import EvalCache
 
 PLAYERS_DIR = Path("players")
 
@@ -116,9 +117,10 @@ def play_one_game(params_white: dict, params_black: dict, seed: int, visualize: 
     random.seed(seed)
     game = HiveGame()
     state = game.getInitialState()
+    cache = EvalCache()
 
-    mcts_white = MCTS(game, **params_white)
-    mcts_black = MCTS(game, **params_black)
+    mcts_white = MCTS(game, cache=cache, **params_white)
+    mcts_black = MCTS(game, cache=cache, **params_black)
 
     if visualize:
         screen = pygame.display.set_mode((800, 600))


### PR DESCRIPTION
## Summary
- track starting visits when loading cached node stats
- adjust sanity assertion to account for cached visits

## Testing
- `python -m py_compile $(git ls-files '*.py')`
