### PR TITLE
Fix pygame dependency in MCTS

### DIFF
--- a/mcts/Mcts.py
+++ b/mcts/Mcts.py
@@ -1,7 +1,11 @@
 import math
 import random
-import pygame
 from typing import Optional, Tuple
+
+try:
+    import pygame
+except ImportError:  # pragma: no cover - pygame optional for headless use
+    pygame = None
 
 from HivePocket.HivePocket import hex_distance, find_queen_position
 
@@ -132,7 +136,8 @@ class MCTS:
 
         for i in range(self.num_iterations):
             # --------------- HOUSEKEEPING ---------------
-            pygame.event.pump()   # keep the window responsive
+            if pygame is not None:
+                pygame.event.pump()   # keep the window responsive
 
             # --------------- SELECTION ------------------
             node = self._select(root)
@@ -156,7 +161,8 @@ class MCTS:
             # --------------- UI CALLBACK ----------------
             if draw_callback is not None:
                 draw_callback(root, i)
-            pygame.time.delay(1)
+            if pygame is not None:
+                pygame.time.delay(1)
 
         # Final sanity: did we update exactly *num_iterations* paths?
         assert root.visit_count == self.num_iterations, (


### PR DESCRIPTION
## Summary
- make `pygame` optional in `mcts/Mcts.py`
- gate calls to `pygame` if the module is not available

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`