### PR TITLE
Add Connect Four tournament

### DIFF
--- a/c4_players/c2.json
+++ b/c4_players/c2.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 200,
+  "max_depth": 42,
+  "c_param": 2.0,
+  "forced_check_depth": 0
+}

--- a/c4_players/c3.json
+++ b/c4_players/c3.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 200,
+  "max_depth": 42,
+  "c_param": 3.0,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter100.json
+++ b/c4_players/iter100.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 100,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter150.json
+++ b/c4_players/iter150.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 150,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter20.json
+++ b/c4_players/iter20.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 20,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter200.json
+++ b/c4_players/iter200.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 200,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter300.json
+++ b/c4_players/iter300.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 300,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter400.json
+++ b/c4_players/iter400.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 400,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter50.json
+++ b/c4_players/iter50.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 50,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_players/iter600.json
+++ b/c4_players/iter600.json
@@ -1,0 +1,6 @@
+{
+  "num_iterations": 600,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/c4_tournament.py
+++ b/c4_tournament.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Round-robin MCTS tournament for Tic-Tac-Toe.
+"""Round-robin MCTS tournament for Connect Four.
 
-This script loads player configurations from ``ttt_players/*.json`` and
+This script loads player configurations from ``c4_players/*.json`` and
 runs a continuous Elo tournament. Results are written to
-``ttt_results.json`` after every game so progress is preserved between
+``c4_results.json`` after every game so progress is preserved between
 runs. The tournament loops endlessly and can be stopped by typing
 ``quit`` (or pressing ``Ctrl+C``) after any game.
 """
@@ -16,11 +16,10 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from mcts.Mcts import MCTS
-from simple_games.tic_tac_toe import TicTacToe
-from simple_games.perfect_tic_tac_toe import PerfectTicTacToePlayer
+from simple_games.connect_four import ConnectFour
 
-PLAYERS_DIR = Path("ttt_players")
-RESULTS_FILE = Path("ttt_results.json")
+PLAYERS_DIR = Path("c4_players")
+RESULTS_FILE = Path("c4_results.json")
 K_FACTOR = 16
 
 
@@ -38,7 +37,7 @@ def load_players() -> Dict[str, dict]:
         with path.open() as f:
             players[path.stem] = json.load(f)
     if not players:
-        raise FileNotFoundError("No player configs found in 'ttt_players/'.")
+        raise FileNotFoundError("No player configs found in 'c4_players/'.")
     return players
 
 
@@ -69,15 +68,10 @@ def next_game(pair_idx: int, orientation: int, total_pairs: int) -> Tuple[int, i
     return pair_idx, orientation
 
 
-def play_one_game(game: TicTacToe, params_x: dict, params_o: dict, seed: int) -> int:
+def play_one_game(game: ConnectFour, params_x: dict, params_o: dict, seed: int) -> int:
     random.seed(seed)
-    def make_player(cfg, role):
-        if cfg.get("type") == "perfect":
-            return PerfectTicTacToePlayer(game, perspective_player=role)
-        return MCTS(game=game, perspective_player=role, **cfg)
-
-    mcts_x = make_player(params_x, "X")
-    mcts_o = make_player(params_o, "O")
+    mcts_x = MCTS(game=game, perspective_player="X", **params_x)
+    mcts_o = MCTS(game=game, perspective_player="O", **params_o)
     state = game.getInitialState()
     while not game.isTerminal(state):
         to_move = game.getCurrentPlayer(state)
@@ -91,7 +85,7 @@ def play_one_game(game: TicTacToe, params_x: dict, params_o: dict, seed: int) ->
 
 
 def run() -> None:
-    game = TicTacToe()
+    game = ConnectFour()
     players = load_players()
     names = list(players)
     pairs = [(i, j) for i in range(len(names)) for j in range(i + 1, len(names))]
@@ -167,17 +161,16 @@ def run() -> None:
 def init_players() -> None:
     PLAYERS_DIR.mkdir(exist_ok=True)
     samples = {
-        "iter20":  {"num_iterations": 20,  "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "iter50":  {"num_iterations": 50,  "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "iter100": {"num_iterations": 100, "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "iter150": {"num_iterations": 150, "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "iter200": {"num_iterations": 200, "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "iter300": {"num_iterations": 300, "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "iter400": {"num_iterations": 400, "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "iter600": {"num_iterations": 600, "max_depth": 9, "c_param": 1.4, "forced_check_depth": 0},
-        "c2":      {"num_iterations": 200, "max_depth": 9, "c_param": 2.0, "forced_check_depth": 0},
-        "c3":      {"num_iterations": 200, "max_depth": 9, "c_param": 3.0, "forced_check_depth": 0},
-        "perfect": {"type": "perfect"},
+        "iter20":  {"num_iterations": 20,  "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "iter50":  {"num_iterations": 50,  "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "iter100": {"num_iterations": 100, "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "iter150": {"num_iterations": 150, "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "iter200": {"num_iterations": 200, "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "iter300": {"num_iterations": 300, "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "iter400": {"num_iterations": 400, "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "iter600": {"num_iterations": 600, "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
+        "c2":      {"num_iterations": 200, "max_depth": 42, "c_param": 2.0, "forced_check_depth": 0},
+        "c3":      {"num_iterations": 200, "max_depth": 42, "c_param": 3.0, "forced_check_depth": 0},
     }
     for name, cfg in samples.items():
         path = PLAYERS_DIR / f"{name}.json"
@@ -192,7 +185,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--init-players",
         action="store_true",
-        help="create sample configs in ttt_players/",
+        help="create sample configs in c4_players/",
     )
     args = parser.parse_args()
 

--- a/simple_games/perfect_tic_tac_toe.py
+++ b/simple_games/perfect_tic_tac_toe.py
@@ -1,0 +1,59 @@
+import random
+from functools import lru_cache
+
+from .tic_tac_toe import TicTacToe
+
+
+class PerfectTicTacToePlayer:
+    """Minimax-based player that never loses."""
+
+    def __init__(self, game: TicTacToe, perspective_player: str):
+        self.game = game
+        self.perspective = perspective_player
+
+    def _serialize(self, state):
+        board = tuple(tuple(cell or '-' for cell in row) for row in state["board"])
+        return board, state["current_player"]
+
+    @lru_cache(maxsize=None)
+    def _minimax(self, board_serialized, to_move):
+        board, _ = board_serialized
+        state = {
+            "board": [list(row) for row in board],
+            "current_player": to_move,
+        }
+        outcome = self.game.getGameOutcome(state)
+        if outcome == self.perspective:
+            return 1
+        if outcome == 'Draw':
+            return 0
+        if outcome is not None:
+            return -1
+
+        next_player = self.game.getOpponent(to_move)
+        actions = self.game.getLegalActions(state)
+        scores = []
+        for action in actions:
+            next_state = self.game.applyAction(state, action)
+            ser = self._serialize(next_state)
+            score = self._minimax(ser, next_state["current_player"])
+            scores.append(score)
+        if to_move == self.perspective:
+            return max(scores)
+        else:
+            return min(scores)
+
+    def search(self, state):
+        actions = self.game.getLegalActions(state)
+        best_score = -float("inf")
+        best_actions = []
+        for action in actions:
+            next_state = self.game.applyAction(state, action)
+            ser = self._serialize(next_state)
+            score = self._minimax(ser, next_state["current_player"])
+            if score > best_score:
+                best_score = score
+                best_actions = [action]
+            elif score == best_score:
+                best_actions.append(action)
+        return random.choice(best_actions)

--- a/ttt_players/perfect.json
+++ b/ttt_players/perfect.json
@@ -1,0 +1,3 @@
+{
+  "type": "perfect"
+}


### PR DESCRIPTION
## Summary
- add `c4_tournament.py` as a round‑robin Elo tournament for Connect Four
- include default MCTS player configs in `c4_players/`
- implement a perfect Tic‑Tac‑Toe player with minimax search
- support the perfect player in the Tic‑Tac‑Toe tournament

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*