### PR TITLE
Add Connect Four visualizer

### DIFF
--- a/c4_tournament.py
+++ b/c4_tournament.py
@@ -16,8 +16,17 @@ import random
 from pathlib import Path
 from typing import Dict, Tuple, List
 
+try:
+    import pygame
+except ImportError:  # pragma: no cover - allow headless use
+    pygame = None
+
 from mcts.Mcts import MCTS
 from simple_games.connect_four import ConnectFour
+try:
+    from simple_games.c4_visualizer import init_display, draw_board
+except Exception:  # pragma: no cover - pygame optional
+    init_display = draw_board = None
 
 PLAYERS_DIR = Path("c4_players")
 RESULTS_FILE = Path("c4_results.json")
@@ -101,11 +110,20 @@ def choose_pair(names: List[str], data: dict) -> Tuple[Tuple[int, int], int]:
     return (i, j), orientation
 
 
-def play_one_game(game: ConnectFour, params_x: dict, params_o: dict, seed: int) -> int:
+def play_one_game(
+    game: ConnectFour,
+    params_x: dict,
+    params_o: dict,
+    seed: int,
+    screen=None,
+) -> int:
     random.seed(seed)
     mcts_x = MCTS(game=game, perspective_player="X", **params_x)
     mcts_o = MCTS(game=game, perspective_player="O", **params_o)
     state = game.getInitialState()
+    if screen is not None:
+        draw_board(screen, state["board"])
+        pygame.event.pump()
     while not game.isTerminal(state):
         to_move = game.getCurrentPlayer(state)
         if to_move == "X":
@@ -113,15 +131,23 @@ def play_one_game(game: ConnectFour, params_x: dict, params_o: dict, seed: int) 
         else:
             action = mcts_o.search(state)
         state = game.applyAction(state, action)
+        if screen is not None:
+            draw_board(screen, state["board"])
+            pygame.event.pump()
+            pygame.time.delay(300)
     outcome = game.getGameOutcome(state)
     return 1 if outcome == "X" else -1 if outcome == "O" else 0
 
 
-def run() -> None:
+def run(display: bool = True) -> None:
     game = ConnectFour()
     players = load_players()
     names = list(players)
     data = load_results(names)
+    if display and pygame is not None and init_display is not None:
+        screen = init_display(game.ROWS, game.COLS)
+    else:
+        screen = None
 
     g = 0
     try:
@@ -139,6 +165,7 @@ def run() -> None:
                 players[x_name],
                 players[o_name],
                 seed=random.randint(0, 2**32 - 1),
+                screen=screen,
             )
 
             key = (
@@ -183,6 +210,9 @@ def run() -> None:
                 break
     except KeyboardInterrupt:
         print("\nInterrupted. Progress saved.")
+    finally:
+        if screen is not None and pygame is not None:
+            pygame.quit()
 
 
 def init_players() -> None:
@@ -214,9 +244,14 @@ if __name__ == "__main__":
         action="store_true",
         help="create sample configs in c4_players/",
     )
+    parser.add_argument(
+        "--no-display",
+        action="store_true",
+        help="run tournament without the pygame visualizer",
+    )
     args = parser.parse_args()
 
     if args.init_players:
         init_players()
     else:
-        run()
+        run(display=not args.no_display)

--- a/simple_games/c4_visualizer.py
+++ b/simple_games/c4_visualizer.py
@@ -1,0 +1,35 @@
+import pygame
+
+CELL_SIZE = 80
+MARGIN = 10
+BACKGROUND_COLOR = (0, 0, 255)
+EMPTY_COLOR = (255, 255, 255)
+X_COLOR = (255, 0, 0)
+O_COLOR = (255, 255, 0)
+
+def init_display(rows=6, cols=7):
+    width = cols * CELL_SIZE + 2 * MARGIN
+    height = rows * CELL_SIZE + 2 * MARGIN
+    pygame.init()
+    screen = pygame.display.set_mode((width, height))
+    pygame.display.set_caption("Connect Four")
+    return screen
+
+def draw_board(screen, board):
+    rows = len(board)
+    cols = len(board[0]) if rows else 0
+    screen.fill(BACKGROUND_COLOR)
+    for c in range(cols):
+        for r in range(rows):
+            x = MARGIN + c * CELL_SIZE + CELL_SIZE // 2
+            y = MARGIN + (rows - 1 - r) * CELL_SIZE + CELL_SIZE // 2
+            pygame.draw.circle(screen, (0, 0, 0), (x, y), CELL_SIZE // 2 - 2)
+            piece = board[r][c]
+            if piece == "X":
+                color = X_COLOR
+            elif piece == "O":
+                color = O_COLOR
+            else:
+                color = EMPTY_COLOR
+            pygame.draw.circle(screen, color, (x, y), CELL_SIZE // 2 - 6)
+    pygame.display.flip()


### PR DESCRIPTION
## Summary
- add simple pygame board renderer for Connect Four
- integrate visualizer with `c4_tournament.py`
- allow disabling display with `--no-display`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*