### PR TITLE
Fix perfect TTT player and tournament paths

### DIFF
--- a/examples/ttt_tournament.py
+++ b/examples/ttt_tournament.py
@@ -15,11 +15,15 @@ import json
 import random
 from pathlib import Path
 from typing import Dict, Tuple, List
+import sys
 
 try:
     import pygame
 except ImportError:  # pragma: no cover - allow headless use
     pygame = None
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+sys.path.append(str(BASE_DIR))
 
 from mcts.Mcts import MCTS
 from simple_games.tic_tac_toe import TicTacToe
@@ -29,8 +33,8 @@ try:
 except Exception:  # pragma: no cover - pygame optional
     init_display = draw_board = None
 
-PLAYERS_DIR = Path("../ttt_players")
-RESULTS_FILE = Path("ttt_results.json")
+PLAYERS_DIR = BASE_DIR / "ttt_players"
+RESULTS_FILE = BASE_DIR / "ttt_results.json"
 K_FACTOR = 16
 
 

--- a/simple_games/perfect_tic_tac_toe.py
+++ b/simple_games/perfect_tic_tac_toe.py
@@ -19,7 +19,7 @@ class PerfectTicTacToePlayer:
     def _minimax(self, board_serialized, to_move):
         board, _ = board_serialized
         state = {
-            "board": [list(row) for row in board],
+            "board": [[None if c == '-' else c for c in row] for row in board],
             "current_player": to_move,
         }
         outcome = self.game.getGameOutcome(state)


### PR DESCRIPTION
## Summary
- restore empty markers when deserializing boards in `PerfectTicTacToePlayer`
- make tournament paths relative to repo root and fix module import when run directly

## Testing
- `python -m unittest tests/test_simple_games_mcts.py -v`