### PR TITLE
Optimize node classes with dataclass slots

### DIFF
--- a/mcts/Mcts.py
+++ b/mcts/Mcts.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import math
 import random
+from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
 try:
@@ -11,6 +14,7 @@ from HivePocket.HivePocket import hex_distance, find_queen_position
 from .eval_cache import EvalCache
 
 
+@dataclass(slots=True)
 class MCTSNode:
     """A single node of the Monte‑Carlo Tree.
 
@@ -20,15 +24,13 @@ class MCTSNode:
     recover the edge data easily.
     """
 
-    def __init__(self, state: dict, parent: Optional["MCTSNode"] = None,
-                 forced_depth_left: int = 0):
-        self.state           = state
-        self.parent          = parent
-        self.children        = {}          # action -> MCTSNode
-        self.visit_count     = 0
-        self.total_value     = 0.0
-        self._legal_override = None        # Optional[set] of forced actions
-        self.forced_depth_left = forced_depth_left
+    state: dict
+    parent: Optional["MCTSNode"] = None
+    forced_depth_left: int = 0
+    children: dict = field(default_factory=dict)
+    visit_count: int = 0
+    total_value: float = 0.0
+    _legal_override: Optional[set] = None
 
     # ---------------------------------------------------------------------
     # Cheap helpers -------------------------------------------------------

--- a/mcts/single_perspective.py
+++ b/mcts/single_perspective.py
@@ -1,17 +1,20 @@
+from __future__ import annotations
+
 import math
 import random
+from dataclasses import dataclass, field
 
+@dataclass(slots=True)
 class SingleTurnNode:
-    def __init__(self, state, parent=None):
-        """
-        state: a game state in which it's perspective_player's turn
-               OR a terminal state (from perspective_player's point of view).
-        """
-        self.state = state
-        self.parent = parent
-        self.children = {}       # Dict[action -> SingleTurnNode]
-        self.visit_count = 0
-        self.total_value = 0.0
+    state: dict
+    parent: "SingleTurnNode" | None = None
+    children: dict = field(default_factory=dict)
+    visit_count: int = 0
+    total_value: float = 0.0
+
+    def __post_init__(self):
+        """Validate that the node state is provided."""
+        assert self.state is not None
 
     @property
     def avg_value(self):

--- a/tests/test_node_slots.py
+++ b/tests/test_node_slots.py
@@ -1,0 +1,19 @@
+import unittest
+from mcts.Mcts import MCTSNode
+from mcts.single_perspective import SingleTurnNode
+
+
+class TestNodeSlots(unittest.TestCase):
+    def test_mctsnode_slots(self):
+        node = MCTSNode({'current_player': 'X'})
+        with self.assertRaises(AttributeError):
+            node.extra_attr = 1
+
+    def test_singleturnnode_slots(self):
+        node = SingleTurnNode({'current_player': 'X'})
+        with self.assertRaises(AttributeError):
+            node.extra_attr = 1
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert `MCTSNode` and `SingleTurnNode` to dataclasses with `slots=True`
- add unit test verifying dataclass slot enforcement

## Testing
- `PYTHONPATH=. python tests/test_node_slots.py`
- `PYTHONPATH=. python tests/test_simple_games_mcts.py`
- `PYTHONPATH=. python tests/test_perfect_tictactoe.py`
- `PYTHONPATH=. python tests/test_tournament_orientation.py`
