### PR TITLE
Add minimax Connect Four player

### DIFF
--- a/c4_players/minimax.json
+++ b/c4_players/minimax.json
@@ -1,0 +1,4 @@
+{
+  "type": "minimax",
+  "depth": 4
+}

--- a/examples/c4_tournament.py
+++ b/examples/c4_tournament.py
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover - allow headless use
 
 from mcts.Mcts import MCTS
 from simple_games.connect_four import ConnectFour
+from simple_games.minimax_connect_four import MinimaxConnectFourPlayer
 try:
     from simple_games.c4_visualizer import init_display, draw_board
 except Exception:  # pragma: no cover - pygame optional
@@ -136,8 +137,14 @@ def play_one_game(
     screen=None,
 ) -> int:
     random.seed(seed)
-    mcts_x = MCTS(game=game, perspective_player="X", **params_x)
-    mcts_o = MCTS(game=game, perspective_player="O", **params_o)
+    def make_player(cfg, role):
+        if cfg.get("type") == "minimax":
+            depth = int(cfg.get("depth", 4))
+            return MinimaxConnectFourPlayer(game, perspective_player=role, depth=depth)
+        return MCTS(game=game, perspective_player=role, **cfg)
+
+    mcts_x = make_player(params_x, "X")
+    mcts_o = make_player(params_o, "O")
     state = game.getInitialState()
     if screen is not None:
         draw_board(screen, state["board"])
@@ -246,6 +253,7 @@ def init_players() -> None:
         "iter6000": {"num_iterations": 6000, "max_depth": 42, "c_param": 1.4, "forced_check_depth": 0},
         "c2":      {"num_iterations": 200, "max_depth": 42, "c_param": 2.0, "forced_check_depth": 0},
         "c3":      {"num_iterations": 200, "max_depth": 42, "c_param": 3.0, "forced_check_depth": 0},
+        "minimax": {"type": "minimax", "depth": 4},
     }
     for name, cfg in samples.items():
         path = PLAYERS_DIR / f"{name}.json"

--- a/simple_games/__init__.py
+++ b/simple_games/__init__.py
@@ -1,0 +1,2 @@
+
+from .minimax_connect_four import MinimaxConnectFourPlayer

--- a/simple_games/minimax_connect_four.py
+++ b/simple_games/minimax_connect_four.py
@@ -1,0 +1,92 @@
+import random
+from functools import lru_cache
+
+from .connect_four import ConnectFour
+
+
+class MinimaxConnectFourPlayer:
+    """Simple depth-limited minimax player for Connect Four."""
+
+    def __init__(self, game: ConnectFour, perspective_player: str, depth: int = 4):
+        self.game = game
+        self.perspective = perspective_player
+        self.depth = depth
+
+    def _serialize(self, state):
+        board = tuple(tuple(cell for cell in row) for row in state["board"])
+        return board, state["current_player"]
+
+    @lru_cache(maxsize=None)
+    def _minimax(self, board_serialized, to_move, depth):
+        board, _ = board_serialized
+        state = {
+            "board": [list(row) for row in board],
+            "current_player": to_move,
+        }
+        outcome = self.game.getGameOutcome(state)
+        if outcome == self.perspective:
+            return 1.0
+        if outcome == "Draw":
+            return 0.0
+        if outcome is not None:
+            return -1.0
+        if depth == 0:
+            return self._heuristic_value(state)
+
+        next_player = self.game.getOpponent(to_move)
+        actions = self.game.getLegalActions(state)
+        scores = []
+        for action in actions:
+            next_state = self.game.applyAction(state, action)
+            ser = self._serialize(next_state)
+            score = self._minimax(ser, next_state["current_player"], depth - 1)
+            scores.append(score)
+        if to_move == self.perspective:
+            return max(scores)
+        else:
+            return min(scores)
+
+    def _heuristic_value(self, state):
+        board = state["board"]
+        player = self.perspective
+        opp = self.game.getOpponent(player)
+        score = 0.0
+        for r in range(self.game.ROWS):
+            for c in range(self.game.COLS):
+                for dr, dc in ((1, 0), (0, 1), (1, 1), (1, -1)):
+                    cells = []
+                    for i in range(4):
+                        rr = r + dr * i
+                        cc = c + dc * i
+                        if 0 <= rr < self.game.ROWS and 0 <= cc < self.game.COLS:
+                            cells.append(board[rr][cc])
+                        else:
+                            break
+                    if len(cells) != 4:
+                        continue
+                    if opp not in cells:
+                        count = cells.count(player)
+                        score += pow(10.0, count - 1)
+                    elif player not in cells:
+                        count = cells.count(opp)
+                        score -= pow(10.0, count - 1)
+        # Clamp score to [-1, 1] for safety
+        if score > 0:
+            return min(1.0, score / 10000.0)
+        else:
+            return max(-1.0, score / 10000.0)
+
+    def search(self, state):
+        actions = self.game.getLegalActions(state)
+        best_score = -float("inf")
+        best_actions = []
+        for action in actions:
+            next_state = self.game.applyAction(state, action)
+            ser = self._serialize(next_state)
+            score = self._minimax(ser, next_state["current_player"], self.depth - 1)
+            if score > best_score:
+                best_score = score
+                best_actions = [action]
+            elif score == best_score:
+                best_actions.append(action)
+        return random.choice(best_actions)

--- a/tests/test_minimax_connect_four.py
+++ b/tests/test_minimax_connect_four.py
@@ -1,0 +1,30 @@
+import sys
+from types import SimpleNamespace
+import unittest
+
+# Provide a minimal pygame stub so imports work
+sys.modules['pygame'] = SimpleNamespace(
+    event=SimpleNamespace(pump=lambda: None),
+    time=SimpleNamespace(delay=lambda x: None)
+)
+
+from simple_games.connect_four import ConnectFour
+from simple_games.minimax_connect_four import MinimaxConnectFourPlayer
+
+
+class TestMinimaxConnectFour(unittest.TestCase):
+    def test_finds_vertical_win(self):
+        game = ConnectFour()
+        state = game.getInitialState()
+        board = state["board"]
+        board[0][0] = "X"
+        board[1][0] = "X"
+        board[2][0] = "X"
+        state["current_player"] = "X"
+        player = MinimaxConnectFourPlayer(game, perspective_player="X", depth=4)
+        best = player.search(state)
+        self.assertEqual(best, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a simple depth-limited minimax player for Connect Four
- integrate the new player into the tournament logic and sample configs
- expose the player via `simple_games` package
- add unit test for the minimax Connect Four player

## Testing
- `python -m unittest discover tests`