### PR TITLE
Optimize ConnectFour evaluation with precomputed lines

### DIFF
--- a/tests/test_connect_four_perf.py
+++ b/tests/test_connect_four_perf.py
@@ -1,0 +1,30 @@
+import time
+import unittest
+from simple_games.connect_four import ConnectFour
+
+
+class TestConnectFourPrecompute(unittest.TestCase):
+    def test_precompute_lines_speed(self):
+        game_fast = ConnectFour(use_precomputed_lines=True)
+        game_slow = ConnectFour(use_precomputed_lines=False)
+        state = game_fast.getInitialState()
+        # Fill a few moves so evaluateState doesn't immediately return terminal
+        state = game_fast.applyAction(state, 0)
+        state = game_fast.applyAction(state, 1)
+        state = game_fast.applyAction(state, 0)
+        state = game_fast.applyAction(state, 1)
+        state = game_fast.applyAction(state, 0)
+
+        def run(g):
+            start = time.time()
+            for _ in range(500):
+                g.evaluateState('X', state)
+            return time.time() - start
+
+        slow_time = run(game_slow)
+        fast_time = run(game_fast)
+        self.assertLess(fast_time, slow_time)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve ConnectFour.evaluation speed with optional precomputed line table
- add a performance test comparing precomputed evaluation vs original

## Testing
- `PYTHONPATH=. python tests/test_connect_four_perf.py`
- `for t in tests/test_chess.py tests/test_node_slots.py tests/test_hybrid_minimax_mcts.py tests/test_minimax_connect_four.py tests/test_perfect_tictactoe.py tests/test_simple_games_mcts.py tests/test_tournament_orientation.py; do PYTHONPATH=. python "$t" || break; done`