### PR TITLE
Improve TicTacToe performance with precomputed lines

### DIFF
--- a/simple_games/tic_tac_toe.py
+++ b/simple_games/tic_tac_toe.py
@@ -1,6 +1,21 @@
 import random
+from typing import List, Tuple
+
 
 class TicTacToe:
+    """Minimal TicTacToe implementation with optional precomputation."""
+
+    def __init__(self, use_precomputed_lines: bool = True):
+        self.use_precomputed_lines = use_precomputed_lines
+        if self.use_precomputed_lines:
+            lines: List[List[Tuple[int, int]]] = []
+            for r in range(3):
+                lines.append([(r, c) for c in range(3)])
+            for c in range(3):
+                lines.append([(r, c) for r in range(3)])
+            lines.append([(i, i) for i in range(3)])
+            lines.append([(i, 2 - i) for i in range(3)])
+            self._precomputed_lines = lines
     def getInitialState(self):
         board = [[None]*3 for _ in range(3)]
         return {"board": board, "current_player": "X"}
@@ -33,16 +48,30 @@ class TicTacToe:
 
     def getGameOutcome(self, state):
         board = state["board"]
-        lines = []
-        for r in range(3):
-            lines.append(board[r])
-        for c in range(3):
-            lines.append([board[r][c] for r in range(3)])
-        lines.append([board[i][i] for i in range(3)])
-        lines.append([board[i][2-i] for i in range(3)])
-        for line in lines:
-            if line[0] is not None and all(cell == line[0] for cell in line):
-                return line[0]
+        if self.use_precomputed_lines:
+            for line in self._precomputed_lines:
+                r0, c0 = line[0]
+                first = board[r0][c0]
+                if first is None:
+                    continue
+                won = True
+                for r, c in line[1:]:
+                    if board[r][c] != first:
+                        won = False
+                        break
+                if won:
+                    return first
+        else:
+            lines = []
+            for r in range(3):
+                lines.append(board[r])
+            for c in range(3):
+                lines.append([board[r][c] for r in range(3)])
+            lines.append([board[i][i] for i in range(3)])
+            lines.append([board[i][2 - i] for i in range(3)])
+            for line in lines:
+                if line[0] is not None and all(cell == line[0] for cell in line):
+                    return line[0]
         if all(cell is not None for row in board for cell in row):
             return "Draw"
         return None

--- a/tests/test_tictactoe_perf.py
+++ b/tests/test_tictactoe_perf.py
@@ -1,0 +1,32 @@
+import time
+import unittest
+from simple_games.tic_tac_toe import TicTacToe
+
+
+class TestTicTacToePrecompute(unittest.TestCase):
+    def test_precompute_lines_speed(self):
+        game_fast = TicTacToe(use_precomputed_lines=True)
+        game_slow = TicTacToe(use_precomputed_lines=False)
+        state = game_fast.getInitialState()
+        # Make a partial board so outcome isn't trivial
+        state["board"][0][0] = "X"
+        state["board"][0][1] = "O"
+        state["board"][1][0] = "X"
+        state["board"][1][1] = "O"
+        state["current_player"] = "X"
+
+        def run(g):
+            start = time.time()
+            for _ in range(50000):
+                g.getGameOutcome(state)
+            return time.time() - start
+
+        slow_times = [run(game_slow) for _ in range(3)]
+        fast_times = [run(game_fast) for _ in range(3)]
+        avg_slow = sum(slow_times) / len(slow_times)
+        avg_fast = sum(fast_times) / len(fast_times)
+        self.assertLess(avg_fast, avg_slow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional precomputation of winning lines in `TicTacToe`
- optimize outcome checks using the precomputed data
- include performance regression test for the new option

## Testing
- `python -m unittest tests.test_tictactoe_perf.TestTicTacToePrecompute.test_precompute_lines_speed`
- `python -m unittest discover tests`