### PR TITLE
Prefer minimax result for hybrid MCTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCTS-Hive
 
-This repository contains a Monte-Carlo Tree Search implementation along with a collection of example scripts and simple board games used for experimentation. The `MCTS` class also exposes an optional depth-limited minimax search. Set the `minimax_depth` parameter when constructing `MCTS` to enable a hybrid that considers both algorithms.
+This repository contains a Monte-Carlo Tree Search implementation along with a collection of example scripts and simple board games used for experimentation. The `MCTS` class also exposes an optional depth-limited minimax search. Set the `minimax_depth` parameter when constructing `MCTS` to enable a hybrid approach. When enabled, the minimax result always overrides the MCTS suggestion.
 
 ## Directory overview
 

--- a/mcts/Mcts.py
+++ b/mcts/Mcts.py
@@ -204,11 +204,8 @@ class MCTS:
 
         best_action = self._best_action(root)
         if self.minimax_depth > 0:
-            mm_action, mm_score = self._minimax_search(root_state, self.minimax_depth)
-            mcts_state = self.game.applyAction(root_state, best_action)
-            mcts_score = self.eval_func(self.perspective_player, mcts_state, self.weights)
-            if mm_score > mcts_score:
-                return mm_action
+            mm_action, _ = self._minimax_search(root_state, self.minimax_depth)
+            return mm_action
         return best_action
 
     # -------------------------------------------------------------


### PR DESCRIPTION
## Summary
- simplify minimax hybrid logic so the minimax move is always used when `minimax_depth` is set
- document the new behavior

## Testing
- `PYTHONPATH=. python -m unittest discover tests`