### PR TITLE
Enhance TTT RL trainer with persistence and controls

### DIFF
--- a/tests/test_rlagent_persistence.py
+++ b/tests/test_rlagent_persistence.py
@@ -1,0 +1,17 @@
+import os
+import tempfile
+import unittest
+from examples.ttt_selfplay_rl import RLAgent
+
+class TestRLAgentPersistence(unittest.TestCase):
+    def test_save_and_load(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "vals.json")
+            agent1 = RLAgent(lr=1.0, epsilon=0.0, storage_path=path)
+            agent1.play_episode()
+            self.assertTrue(agent1.values)
+            agent2 = RLAgent(lr=1.0, epsilon=0.0, storage_path=path)
+            self.assertEqual(agent1.values, agent2.values)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- persist RLAgent values between runs with JSON storage
- add reset capability and fast/slow speed toggle to UI
- reduce UI board size to keep buttons visible
- add regression test for RLAgent persistence

## Testing
- `python -m unittest discover tests -v`