### PR TITLE
Add Connect Four AlphaGo-style self-play

### DIFF
--- a/examples/c4_tournament.py
+++ b/examples/c4_tournament.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: no cover - allow headless use
 from mcts.Mcts import MCTS
 from simple_games.connect_four import ConnectFour
 from simple_games.minimax_connect_four import MinimaxConnectFourPlayer
+from examples.c4_zero import ZeroC4Player, C4ZeroNet, load_weights
 try:
     from simple_games.c4_visualizer import init_display, draw_board
 except Exception:  # pragma: no cover - pygame optional
@@ -141,6 +142,11 @@ def play_one_game(
         if cfg.get("type") == "minimax":
             depth = int(cfg.get("depth", 4))
             return MinimaxConnectFourPlayer(game, perspective_player=role, depth=depth)
+        if cfg.get("type") == "zero":
+            net = C4ZeroNet()
+            load_weights(net, Path(cfg["weights"]))
+            temp = float(cfg.get("temperature", 0.0))
+            return ZeroC4Player(net, temperature=temp)
         return MCTS(game=game, perspective_player=role, **cfg)
 
     mcts_x = make_player(params_x, "X")

--- a/examples/c4_zero.py
+++ b/examples/c4_zero.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Minimal AlphaGo-style self-play training for Connect Four.
+
+This script implements a small convolutional network and a short
+self-play loop so unit tests can run quickly. Training data and
+network weights can be saved and reloaded. The :class:`ZeroC4Player`
+class wraps a trained network for use in ``c4_tournament.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from pathlib import Path
+from typing import List, Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except Exception:  # pragma: no cover - torch optional
+    torch = None
+    nn = None
+    F = None
+
+HAS_TORCH = torch is not None
+
+from simple_games.connect_four import ConnectFour
+
+# ---------------------------------------------------------------------------
+# Encoding
+# ---------------------------------------------------------------------------
+BOARD_H = ConnectFour.ROWS
+BOARD_W = ConnectFour.COLS
+
+
+def encode_state(state: dict, perspective: str) -> torch.Tensor:
+    """Return a 3×6×7 tensor representing ``state`` from ``perspective``."""
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for encode_state")
+    t = torch.zeros(3, BOARD_H, BOARD_W)
+    for r in range(BOARD_H):
+        for c in range(BOARD_W):
+            piece = state["board"][r][c]
+            if piece == perspective:
+                t[0, r, c] = 1.0
+            elif piece is not None:
+                t[1, r, c] = 1.0
+    t[2].fill_(1.0 if state["current_player"] == perspective else 0.0)
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Neural network
+# ---------------------------------------------------------------------------
+if HAS_TORCH:
+    class C4ZeroNet(nn.Module):
+        """Tiny policy/value network for Connect Four."""
+
+        def __init__(self, channels: int = 32):
+            super().__init__()
+            self.conv = nn.Sequential(
+                nn.Conv2d(3, channels, 3, padding=1), nn.ReLU(),
+                nn.Conv2d(channels, channels, 3, padding=1), nn.ReLU(),
+            )
+            self.policy = nn.Sequential(
+                nn.Flatten(),
+                nn.Linear(channels * BOARD_H * BOARD_W, 64),
+                nn.ReLU(),
+                nn.Linear(64, BOARD_W),
+            )
+            self.value = nn.Sequential(
+                nn.Flatten(),
+                nn.Linear(channels * BOARD_H * BOARD_W, 64),
+                nn.ReLU(),
+                nn.Linear(64, 1),
+                nn.Tanh(),
+            )
+
+        def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+            x = self.conv(x)
+            return self.policy(x), self.value(x).squeeze(1)
+else:  # pragma: no cover - torch not installed
+    class C4ZeroNet:
+        def __init__(self, *a, **k):
+            raise RuntimeError("PyTorch not available")
+
+
+# ---------------------------------------------------------------------------
+# Self-play generation and training
+# ---------------------------------------------------------------------------
+
+def play_one_game(net: C4ZeroNet, eps: float = 0.1) -> List[Tuple[torch.Tensor, int, float]]:
+    """Play one self-play game and return training tuples."""
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for play_one_game")
+    game = ConnectFour()
+    state = game.getInitialState()
+    hist: List[Tuple[torch.Tensor, int]] = []
+    while not game.isTerminal(state):
+        tensor = encode_state(state, state["current_player"])  # type: ignore[arg-type]
+        with torch.no_grad():
+            logits, _ = net(tensor.unsqueeze(0))
+            probs = logits.softmax(1)[0].tolist()
+        legal = game.getLegalActions(state)
+        masked = [probs[a] if a in legal else 0.0 for a in range(BOARD_W)]
+        if sum(masked) == 0:
+            action = random.choice(legal)
+        else:
+            if random.random() < eps:
+                action = random.choice(legal)
+            else:
+                action = max(legal, key=lambda a: masked[a])
+        hist.append((tensor, action))
+        state = game.applyAction(state, action)
+
+    outcome = game.getGameOutcome(state)
+    if outcome == "Draw":
+        z = 0.0
+    else:
+        z = 1.0 if outcome == "X" else -1.0
+    data = []
+    player = "X"
+    for tensor, action in hist:
+        reward = z if player == "X" else -z
+        data.append((tensor, action, reward))
+        player = "O" if player == "X" else "X"
+    return data
+
+
+def train_step(net: C4ZeroNet, batch, opt) -> float:
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for train_step")
+    states = torch.stack([s for s, _, _ in batch])
+    actions = torch.tensor([a for _, a, _ in batch], dtype=torch.long)
+    values = torch.tensor([v for _, _, v in batch], dtype=torch.float32)
+    logits, v_pred = net(states)
+    loss_p = F.cross_entropy(logits, actions)
+    loss_v = F.mse_loss(v_pred.squeeze(), values)
+    loss = loss_p + loss_v
+    opt.zero_grad(); loss.backward(); opt.step()
+    return float(loss.item())
+
+
+def evaluate_loss(net: C4ZeroNet, data) -> float:
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for evaluate_loss")
+    with torch.no_grad():
+        states = torch.stack([s for s, _, _ in data])
+        actions = torch.tensor([a for _, a, _ in data], dtype=torch.long)
+        values = torch.tensor([v for _, _, v in data], dtype=torch.float32)
+        logits, v_pred = net(states)
+        loss_p = F.cross_entropy(logits, actions)
+        loss_v = F.mse_loss(v_pred.squeeze(), values)
+        return float((loss_p + loss_v).item())
+
+
+def save_dataset(data, path: Path) -> None:
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for save_dataset")
+    torch.save([(s.numpy(), a, v) for s, a, v in data], path)
+
+
+def load_dataset(path: Path):
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for load_dataset")
+    raw = torch.load(path)
+    return [(torch.tensor(s), a, v) for s, a, v in raw]
+
+
+def save_weights(net: C4ZeroNet, path: Path) -> None:
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for save_weights")
+    torch.save(net.state_dict(), path)
+
+
+def load_weights(net: C4ZeroNet, path: Path) -> None:
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for load_weights")
+    net.load_state_dict(torch.load(path))
+
+
+# ---------------------------------------------------------------------------
+# Network-backed player
+# ---------------------------------------------------------------------------
+class ZeroC4Player:
+    """Connect Four player that selects moves using a trained network."""
+
+    def __init__(self, net: C4ZeroNet, temperature: float = 0.0):
+        if not HAS_TORCH:
+            raise RuntimeError("PyTorch is required for ZeroC4Player")
+        self.net = net
+        self.temperature = temperature
+        self.game = ConnectFour()
+
+    def search(self, state: dict) -> int:
+        tensor = encode_state(state, state["current_player"]).unsqueeze(0)
+        with torch.no_grad():
+            logits, _ = self.net(tensor)
+            probs = logits.softmax(1)[0].tolist()
+        legal = self.game.getLegalActions(state)
+        masked = [probs[a] if a in legal else 0.0 for a in range(BOARD_W)]
+        if sum(masked) == 0:
+            return random.choice(legal)
+        if self.temperature > 0:
+            dist = [p ** (1 / self.temperature) for p in masked]
+            s = sum(dist)
+            dist = [p / s for p in dist]
+            return random.choices(range(BOARD_W), dist)[0]
+        return max(legal, key=lambda a: masked[a])
+
+
+# ---------------------------------------------------------------------------
+# Command-line interface
+# ---------------------------------------------------------------------------
+
+def run(args) -> None:
+    if not HAS_TORCH:
+        raise RuntimeError("PyTorch is required for training")
+    net = C4ZeroNet()
+    opt = torch.optim.Adam(net.parameters(), lr=1e-2)
+    buffer = []
+    for _ in range(args.games):
+        buffer.extend(play_one_game(net))
+    print(f"Generated {len(buffer)} samples")
+    loss_before = evaluate_loss(net, buffer)
+    for _ in range(args.epochs):
+        batch = random.sample(buffer, min(len(buffer), args.batch))
+        train_step(net, batch, opt)
+    loss_after = evaluate_loss(net, buffer)
+    print(f"Loss {loss_before:.3f} -> {loss_after:.3f}")
+    if args.data_path:
+        save_dataset(buffer, Path(args.data_path))
+    if args.weights_path:
+        save_weights(net, Path(args.weights_path))
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser()
+    p.add_argument("--games", type=int, default=2)
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--batch", type=int, default=32)
+    p.add_argument("--data-path")
+    p.add_argument("--weights-path")
+    return p
+
+
+if __name__ == "__main__":
+    run(parser().parse_args())

--- a/examples/offline_ttt_perfect_policy.py
+++ b/examples/offline_ttt_perfect_policy.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Precompute the perfect Tic-Tac-Toe policy offline.
+
+This script exhaustively enumerates every reachable Tic-Tac-Toe state.
+For each position it computes the minimax value and records the optimal
+moves for the side to play. The resulting dictionary is saved to
+``ttt_perfect_policy.json`` and can be used by any agent that needs a
+lookup table of perfect play.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Dict, List, Tuple
+
+from simple_games.tic_tac_toe import TicTacToe
+
+
+GameState = Tuple[Tuple[Tuple[str | None, ...], ...], str]
+
+game = TicTacToe()
+
+def serialize(state: dict) -> GameState:
+    board = tuple(tuple(cell for cell in row) for row in state["board"])
+    return board, state["current_player"]
+
+@lru_cache(maxsize=None)
+def minimax(board_serialized: GameState, to_move: str) -> int:
+    board, _ = board_serialized
+    state = {"board": [list(row) for row in board], "current_player": to_move}
+    outcome = game.getGameOutcome(state)
+    if outcome == "X":
+        return 1
+    if outcome == "O":
+        return -1
+    if outcome == "Draw":
+        return 0
+    scores = []
+    for action in game.getLegalActions(state):
+        ns = game.applyAction(state, action)
+        score = minimax(serialize(ns), ns["current_player"])
+        scores.append(score)
+    return max(scores) if to_move == "X" else min(scores)
+
+def build_policy(state: dict, policy: Dict[GameState, List[Tuple[int, int]]]) -> None:
+    key = serialize(state)
+    if key in policy:
+        return
+    if game.isTerminal(state):
+        policy[key] = []
+        return
+    action_scores = []
+    for action in game.getLegalActions(state):
+        ns = game.applyAction(state, action)
+        score = minimax(serialize(ns), ns["current_player"])
+        if state["current_player"] == "O":
+            score = -score
+        action_scores.append((score, action))
+        build_policy(ns, policy)
+    best = max(s for s, _ in action_scores)
+    best_actions = [a for s, a in action_scores if s == best]
+    policy[key] = best_actions
+
+def main() -> None:
+    policy: Dict[GameState, List[Tuple[int, int]]] = {}
+    initial = game.getInitialState()
+    build_policy(initial, policy)
+    with open("ttt_perfect_policy.json", "w") as f:
+        json.dump({str(k): v for k, v in policy.items()}, f)
+    print(f"Enumerated {len(policy)} states.")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_c4_zero.py
+++ b/tests/test_c4_zero.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+import unittest
+
+import examples.c4_zero as c4_zero
+
+if not c4_zero.HAS_TORCH:  # pragma: no cover - skip if torch missing
+    raise unittest.SkipTest("PyTorch not available")
+
+import torch
+
+from examples.c4_zero import (
+    C4ZeroNet,
+    ZeroC4Player,
+    play_one_game,
+    train_step,
+    evaluate_loss,
+    save_dataset,
+    load_dataset,
+    save_weights,
+    load_weights,
+)
+from simple_games.connect_four import ConnectFour
+
+
+class TestC4ZeroTraining(unittest.TestCase):
+    def test_training_and_persistence(self):
+        net = C4ZeroNet()
+        data = []
+        for _ in range(2):
+            data.extend(play_one_game(net))
+        loss_before = evaluate_loss(net, data)
+        opt = torch.optim.SGD(net.parameters(), lr=0.01)
+        for _ in range(5):
+            train_step(net, data, opt)
+        loss_after = evaluate_loss(net, data)
+        self.assertLess(loss_after, loss_before)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dpath = os.path.join(tmp, "data.pth")
+            wpath = os.path.join(tmp, "weights.pth")
+            save_dataset(data, dpath)
+            save_weights(net, wpath)
+            data2 = load_dataset(dpath)
+            net2 = C4ZeroNet()
+            load_weights(net2, wpath)
+            self.assertEqual(len(data), len(data2))
+            game = ConnectFour()
+            state = game.getInitialState()
+            player = ZeroC4Player(net2)
+            action = player.search(state)
+            self.assertIn(action, game.getLegalActions(state))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `c4_zero.py` with a small self-play training loop
- add support for `ZeroC4Player` in the tournament
- test training, persistence and basic gameplay of the new agent

## Testing
- `python -m unittest discover tests`