### PR TITLE
Fix minimax player ignoring immediate wins

### DIFF
--- a/simple_games/minimax_connect_four.py
+++ b/simple_games/minimax_connect_four.py
@@ -87,6 +87,15 @@ class MinimaxConnectFourPlayer:
 
     def search(self, state):
         actions = self.game.getLegalActions(state)
+        winning_actions = []
+        for action in actions:
+            next_state = self.game.applyAction(state, action)
+            if self.game.getGameOutcome(next_state) == self.perspective:
+                winning_actions.append(action)
+
+        if winning_actions:
+            return random.choice(winning_actions)
+
         best_score = -float("inf")
         best_actions = []
         for action in actions:


### PR DESCRIPTION
## Summary
- update minimax search to look for direct wins first

## Testing
- `PYTHONPATH=. python tests/test_minimax_connect_four.py`
- `PYTHONPATH=. python tests/test_connect_four_perf.py`
