### PR TITLE
Simplify C4 zero training defaults

### DIFF
--- a/c4_players/zero.json
+++ b/c4_players/zero.json
@@ -1,0 +1,5 @@
+{
+  "type": "zero",
+  "weights": "c4_weights/weights.pth",
+  "temperature": 0.0
+}


### PR DESCRIPTION
## Summary
- simplify `examples/c4_zero.py` so it doesn't rely on CLI arguments
- always store training data in `c4_data/data.pth` and weights in `c4_weights/weights.pth`
- add a Connect Four tournament player configuration that loads the new weights

## Testing
- `python -m unittest discover tests`