### PR TITLE
Add Hive board documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains a Monte-Carlo Tree Search implementation along with a c
 - `examples/` – Scripts and experiments demonstrating usage of the library.
 - `tests/` – Unit tests.
 - `docs/` – Additional documentation including [`connect_four_board.md`](docs/connect_four_board.md)
+  , [`hive_board_representation.md`](docs/hive_board_representation.md)
   , [`single_perspective_mcts.md`](docs/single_perspective_mcts.md)
   and [`tic_tac_toe_td_rl.md`](docs/tic_tac_toe_td_rl.md).
 

--- a/docs/hive_board_representation.md
+++ b/docs/hive_board_representation.md
@@ -1,0 +1,57 @@
+# Hive Board Representation and Symmetry
+
+The `HivePocket` module models the hexagonal board using **axial coordinates**
+`(q, r)`. Each coordinate identifies a hex cell and maps to a *stack* of
+pieces on that cell. A board state is therefore represented as a dictionary:
+
+```python
+board = {
+    (q, r): [(owner, piece_type), ...],
+    ...
+}
+```
+
+Pieces are stacked in a list with the bottom piece first and the top piece last.
+Only the top piece of each stack can move. The coordinate `(0, 0)` is arbitrary
+but all movement functions rely on the relative axial directions:
+
+```
+      \  (0,1)  /
+(-1,0) - (0,0) - (1,0)
+      /  (0,-1) \
+```
+
+The six neighbour deltas are `(1,0)`, `(-1,0)`, `(0,1)`, `(0,-1)`, `(1,-1)` and
+`(-1,1)`.
+
+## Canonicalisation with Symmetry
+
+Hive positions can be rotated or reflected without changing the underlying
+state. To avoid storing duplicate transpositions the function
+`canonical_board_key` computes a canonical representation that is invariant
+under all 12 rotations and reflections.
+
+1. **Convert axial coordinates to cube coordinates** `(x, y, z)` using
+   `x = q`, `z = r` and `y = -x - z`.
+2. **Generate all 12 symmetry transforms**:
+   - six rotations in 60° steps using `_rotate_cube`;
+   - after rotating, optionally reflect across the `x = z` axis with
+     `_reflect_cube`.
+3. **Apply each transform** to every occupied coordinate, sort the resulting
+   items and pick the lexicographically smallest tuple. This unique tuple is the
+   canonical board key.
+
+The process in pseudo-code:
+
+```
+for k in range(12):
+    items = []
+    for (q, r), stack in board.items():
+        q2, r2 = transform(q, r, k)  # rotate then reflect
+        items.append(((q2, r2), tuple(stack)))
+    representations.append(tuple(sorted(items)))
+return min(representations)
+```
+
+Using this key allows the MCTS cache to recognise board states that are the same
+up to rotation or reflection, greatly reducing duplication.


### PR DESCRIPTION
## Summary
- document Hive board representation and symmetry handling
- link new doc from README

## Testing
- `PYTHONPATH=. python -m unittest discover tests`