### PR TITLE
Document forced move pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository contains a Monte-Carlo Tree Search implementation along with a c
 - `docs/` – Additional documentation including [`connect_four_board.md`](docs/connect_four_board.md)
   , [`hive_board_representation.md`](docs/hive_board_representation.md)
   , [`single_perspective_mcts.md`](docs/single_perspective_mcts.md)
-  and [`tic_tac_toe_td_rl.md`](docs/tic_tac_toe_td_rl.md).
+  , [`tic_tac_toe_td_rl.md`](docs/tic_tac_toe_td_rl.md)
+  , [`forced_move_pruning.md`](docs/forced_move_pruning.md).
 
 Player configuration JSON files for Connect Four and Tic-Tac-Toe remain in `c4_players/` and `ttt_players/` respectively.
 

--- a/docs/forced_move_pruning.md
+++ b/docs/forced_move_pruning.md
@@ -1,0 +1,50 @@
+# Forced Move Pruning in MCTS
+
+The `MCTS` implementation includes an optional *forced move* pruning step
+that tries to detect immediate wins (or threats) before expanding a node.
+When a node is expanded with a non‑zero `forced_depth_left`, the algorithm
+performs a depth limited search to see whether the current player can force
+a win or avoid defeat within that many moves.
+
+If a winning line is found, only the winning action is kept.  Otherwise the
+children are pruned to the subset of moves that do not allow the opponent a
+forced reply.  This reduces the branching factor in tactical situations
+where the correct continuation is forced.
+
+```
+expand(node):
+    if node.forced_depth_left > 0:
+        win, safe = forced_move_check(node.state, node.forced_depth_left)
+        if win is not None:
+            allowed = [win]
+        else:
+            allowed = safe
+        node.prune_to_actions(allowed)
+        node.forced_depth_left = 0
+    # normal expansion continues here
+```
+
+The helper `_forced_move_check` uses `_forced_check_depth_limited` to
+verify forced wins recursively:
+
+```
+forced_move_check(state, depth):
+    for action in legal_moves(state):
+        next_state = apply(action, state)
+        if is_terminal(next_state):
+            if winner(next_state) == current_player(state):
+                return action, []
+            if winner is draw:
+                add action to safe moves
+            continue
+        if forced_check_depth_limited(next_state, current_player, depth-1):
+            return action, []           # winning line found
+        if not forced_check_depth_limited(next_state, opponent, depth-1):
+            add action to safe moves    # opponent has no forced win
+    return None, safe moves
+```
+
+This procedure is much cheaper than a full minimax search yet can quickly
+recognise sequences of mandatory moves.  It is particularly useful in
+Hive where piece placements can create threats that must be answered
+immediately.

--- a/mcts/Mcts.py
+++ b/mcts/Mcts.py
@@ -237,6 +237,7 @@ class MCTS:
     # Forced‑move pruning (unchanged) ------------------------------
     # -------------------------------------------------------------
     def _forced_check_depth_limited(self, state, player, depth):
+        """Return True if ``player`` can force a win within ``depth`` moves."""
         outcome = self.game.getGameOutcome(state)
         if outcome is not None:
             return outcome == player
@@ -245,17 +246,38 @@ class MCTS:
         to_move = self.game.getCurrentPlayer(state)
         actions = self.game.getLegalActions(state)
         if to_move == player:
-            return any(self._forced_check_depth_limited(self.game.applyAction(state, a), player, depth - 1)
-                       for a in actions)
+            return any(
+                self._forced_check_depth_limited(
+                    self.game.applyAction(state, a), player, depth - 1)
+                for a in actions)
         else:
-            return all(self._forced_check_depth_limited(self.game.applyAction(state, a), player, depth - 1)
-                       for a in actions)
+            return all(
+                self._forced_check_depth_limited(
+                    self.game.applyAction(state, a), player, depth - 1)
+                for a in actions)
 
     def _forced_move_check(self, state, depth):
+        """Return a winning move or the subset of actions that are safe.
+
+        Parameters
+        ----------
+        state : dict
+            Current game state.
+        depth : int
+            How deep to search for forced wins.
+
+        Returns
+        -------
+        Tuple[action | None, list[action]]
+            ``(winning_action, safe_actions)`` where ``winning_action`` is a
+            move that wins immediately or via a depth-limited forced line.  If
+            no such move exists it is ``None`` and ``safe_actions`` contains the
+            legal moves that do not allow the opponent a forced reply.
+        """
         current = self.game.getCurrentPlayer(state)
-        legal   = self.game.getLegalActions(state)
+        legal = self.game.getLegalActions(state)
         forced_win = None
-        safe        = []
+        safe = []
         for a in legal:
             nxt = self.game.applyAction(state, a)
             out = self.game.getGameOutcome(nxt)


### PR DESCRIPTION
## Summary
- add docstrings for forced move pruning helpers in `MCTS`
- document the pruning algorithm in `docs/forced_move_pruning.md`
- link to the new doc from the README

## Testing
- `python -m unittest discover tests`