### PR TITLE
Add network-guided MCTS option

### DIFF
--- a/c4_players/mcts_zero.json
+++ b/c4_players/mcts_zero.json
@@ -1,0 +1,9 @@
+{
+  "type": "mcts_zero",
+  "weights": "c4_weights/weights.pth",
+  "temperature": 0.0,
+  "num_iterations": 200,
+  "max_depth": 42,
+  "c_param": 1.4,
+  "forced_check_depth": 0
+}

--- a/mcts/Mcts.py
+++ b/mcts/Mcts.py
@@ -178,12 +178,7 @@ class MCTS:
                 node = node.expand(self.game, self)
 
             # --------------- SIMULATION -----------------
-            sim_val = self.game.simulateRandomPlayout(
-                node.state,
-                self.perspective_player,
-                max_depth=self.max_depth,
-                eval_func=self.eval_func,
-                weights=self.weights)
+            sim_val = self._simulate(node.state)
             assert -1.0 - 1e-6 <= sim_val <= 1.0 + 1e-6, "simulateRandomPlayout must return in [-1,1]"
 
             # --------------- BACKPROP -------------------
@@ -223,6 +218,16 @@ class MCTS:
             if child.visit_count > best_visits:
                 best_action, best_visits = action, child.visit_count
         return best_action
+
+    def _simulate(self, state: dict) -> float:
+        """Run a default random playout from ``state``."""
+        return self.game.simulateRandomPlayout(
+            state,
+            self.perspective_player,
+            max_depth=self.max_depth,
+            eval_func=self.eval_func,
+            weights=self.weights,
+        )
 
     def _backpropagate(self, node: MCTSNode, value: float):
         while node is not None:


### PR DESCRIPTION
## Summary
- hook MCTS search through a new `_simulate` method
- implement `ZeroGuidedMCTS` in `c4_tournament` for neural-guided playouts
- add config example `mcts_zero.json`

## Testing
- `python -m unittest discover -v tests`