### PR TITLE
Fix overlay initialization for C4 heatmap

### DIFF
--- a/simple_games/c4_visualizer.py
+++ b/simple_games/c4_visualizer.py
@@ -63,6 +63,7 @@ def draw_board_with_action_values(
     rows = len(board)
     cols = len(board[0]) if rows else 0
     overlay = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
+    overlay.fill((0, 0, 0, 0))
     max_visits = max(v[1] for v in values.values()) if values else 1
     for col in range(cols):
         if col not in values:


### PR DESCRIPTION
## Summary
- ensure Connect Four heatmap overlay surface starts fully transparent

## Testing
- `python tests/test_minimax_connect_four.py`
- `python tests/test_connect_four_outcomes.py`
- `python tests/test_perfect_tictactoe.py`
- `python tests/test_simple_games_mcts.py`
- `python tests/test_chess.py`
- `python tests/test_node_slots.py`
- `python tests/test_hive_endgame.py`
- `python tests/test_tictactoe_perf.py`
- `python tests/test_hybrid_minimax_mcts.py`
- `python tests/test_tournament_orientation.py`
- `python tests/test_legal_cache_performance.py`
- `python tests/test_rlagent_persistence.py`
- `python tests/test_connect_four_perf.py`
- `python tests/test_c4_zero.py` *(fails: PyTorch not available)*